### PR TITLE
Various fixes and customizations for Docker image builds of reproduce

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM ocaml/opam:debian-12-ocaml-5.3
+LABEL authors=Deducteam
+
+RUN sudo apt update
+RUN sudo apt install -y perl pkg-config libpcre2-dev m4 libgmp-dev libev-dev libssl-dev
+
+COPY --chown=opam:opam ../coq-hol-light /home/opam/coq-hol-light
+RUN export HOLLIGHT_DIR=`pwd`/hol-light
+RUN export HOL2DK_DIR=`pwd`/hol2dk
+
+WORKDIR /home/opam/coq-hol-light
+RUN ./reproduce --only 2
+# RUN ./reproduce --only 3
+# RUN ./reproduce --only 4
+# RUN ./reproduce --only 5
+# RUN ./reproduce --only 6
+# RUN ./reproduce --only 7
+# RUN ./reproduce --only 8
+# RUN ./reproduce --only 9

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY --chown=opam:opam . /home/opam/coq-hol-light
 RUN export HOLLIGHT_DIR=`pwd`/hol-light
 RUN export HOL2DK_DIR=`pwd`/hol2dk
 
-WORKDIR /home/opam/coq-hol-light
+WORKDIR $HOME/coq-hol-light
 RUN ./reproduce --only 2
 RUN ./reproduce --only 3
 RUN ./reproduce --only 4

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ LABEL authors=Deducteam
 
 RUN sudo apt update
 RUN sudo apt install -y perl pkg-config libpcre2-dev m4 libgmp-dev libev-dev libssl-dev
-
-COPY --chown=opam:opam . /home/opam/coq-hol-light
+RUN git clone --depth 1 https://github.com/Alidra/coq-hol-light.git
+# COPY --chown=opam:opam . /home/opam/coq-hol-light
 RUN export HOLLIGHT_DIR=`pwd`/hol-light
 RUN export HOL2DK_DIR=`pwd`/hol2dk
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,16 +4,18 @@ LABEL authors=Deducteam
 RUN sudo apt update
 RUN sudo apt install -y perl pkg-config libpcre2-dev m4 libgmp-dev libev-dev libssl-dev
 
-COPY --chown=opam:opam ../coq-hol-light /home/opam/coq-hol-light
+COPY --chown=opam:opam . /home/opam/coq-hol-light
 RUN export HOLLIGHT_DIR=`pwd`/hol-light
 RUN export HOL2DK_DIR=`pwd`/hol2dk
 
 WORKDIR /home/opam/coq-hol-light
 RUN ./reproduce --only 2
-# RUN ./reproduce --only 3
-# RUN ./reproduce --only 4
-# RUN ./reproduce --only 5
-# RUN ./reproduce --only 6
-# RUN ./reproduce --only 7
-# RUN ./reproduce --only 8
-# RUN ./reproduce --only 9
+RUN ./reproduce --only 3
+RUN ./reproduce --only 4
+RUN ./reproduce --only 5
+RUN ./reproduce --only 6
+RUN ./reproduce --only 7
+RUN ./reproduce --only 8
+RUN ./reproduce --only 9
+
+RUN sudo apt install -y htop

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,5 +17,3 @@ RUN ./reproduce --only 6
 RUN ./reproduce --only 7
 RUN ./reproduce --only 8
 RUN ./reproduce --only 9
-
-RUN sudo apt install -y htop

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,3 +17,6 @@ RUN ./reproduce --only 6
 RUN ./reproduce --only 7
 RUN ./reproduce --only 8
 RUN ./reproduce --only 9
+
+ENTRYPOINT ["./reproduce"]
+CMD ["-y", "10"]

--- a/hol2dk.singularity
+++ b/hol2dk.singularity
@@ -1,0 +1,22 @@
+Bootstrap: docker
+From: abdelghanialidra/hol2dk:0.0.9
+
+%help
+    to build a .sif image from this file use
+    sudo singularity build hol2dk.0.0.10.sif hol2dk.singularity
+    
+%environment
+    HOME=/home/opam
+
+%runscript
+    exec /bin/bash "$@"
+
+%post
+    echo "setting home directory"
+    export HOME=/home/opam
+    echo "initializing opam"
+    opam init
+    eval $(opam env)
+    apt install -y htop
+    chmod 777 $HOME
+    echo "End of build phase"

--- a/reproduce
+++ b/reproduce
@@ -69,6 +69,8 @@ ask() {
     then
         read -p "$1 (y/n)? " answer
         echo $answer
+    else
+        echo y
     fi
 }
 

--- a/reproduce
+++ b/reproduce
@@ -17,17 +17,19 @@ camlp5_version=8.03.05
 hollight_file=Multivariate/make_complex.ml
 base=`basename $hollight_file .ml`
 root_path=HOLLight
-jobs='-j32'
+: "${NB_CORES:=$(nproc)}"
+jobs="-j$NB_CORES"
 
 one_stage="false"
 
 usage() {
-    echo "usage: `basename $0` [STAGE_NUMBER]"
+    echo "usage: `NB_CORES= [NBRE_OF_AVAILABLE_CORES] basename $0` [STAGE_NUMBER]"
     echo
-    echo 'do stages from STAGE_NUMBER or last failing stage'
+    echo 'do stages from STAGE_NUMBER or last failing stage using NBRE_OF_AVAILABLE_CORES jobs'
     echo
     echo 'options:'
     echo '  -h|--help: print help'
+    echo '  -o|--only: do the provided stage only without following ones'
     echo '  -y: do not ask for user input, proceed automatically'
     echo
     echo 'stages:'
@@ -274,16 +276,13 @@ stage() {
     fi
 }
 
-if test -n "$2"
-then
-    # echo "found a second parameter"
+while test -n "$2"
+do
     shift
-    # echo new parameters are $*
-fi
+done
 
 if test -n "$1"
 then
-    # echo first argument is $1
     echo `expr $1 - 1` > STAGE
 fi
 

--- a/reproduce
+++ b/reproduce
@@ -38,6 +38,7 @@ parse_args() {
         case $1 in
             -h|--help) usage; exit 0;;
             -y) do_not_ask=1; shift; parse_args $*;;
+            -o|--only) one_stage="true";shift; parse_args $*;;
             *)
                 if test $1 -le 0 -o $1 -gt 15
                 then
@@ -255,7 +256,12 @@ stage() {
         echo '------------------------------------------------------------'
         echo stage $*
         $2
-        echo $1 > STAGE
+        if test $one_stage -eq "true"
+        then
+            echo 20 > STAGE
+        else
+            echo $1 > STAGE
+        fi
     fi
 }
 

--- a/reproduce
+++ b/reproduce
@@ -90,15 +90,16 @@ checkout_commit() {
 #usage: install_commit url commit
 install_commit() {
     checkout_commit $*
-    if test `git branch | grep reproduce | wc -l` -gt 0
-    then
-        d=`basename $1 .git`
-        cd $d
-        git checkout -b reproduce
-        echo opam install $d ...
-        opam install -y .
-        cd ..
-    fi
+    # if test `git branch | grep reproduce | wc -l` -gt 0
+    # then
+    d=`basename $1 .git`
+    cd $d
+    git checkout -b reproduce
+    echo opam install $d ...
+    opam install -y .
+    cd ..
+    echo $d installed successfully
+    # fi
 }
 
 create_opam_switch() {
@@ -117,6 +118,8 @@ install_hollight_deps() {
 }
 
 install_lambdapi() {
+    # newer versions of cmdliner break old versions of LP
+    opam install -y cmdliner.1.3.0
     install_commit https://github.com/Deducteam/lambdapi.git $lambdapi_commit
 }
 
@@ -273,11 +276,14 @@ stage() {
 
 if test -n "$2"
 then
+    # echo "found a second parameter"
     shift
+    # echo new parameters are $*
 fi
 
 if test -n "$1"
 then
+    # echo first argument is $1
     echo `expr $1 - 1` > STAGE
 fi
 

--- a/reproduce
+++ b/reproduce
@@ -19,6 +19,8 @@ base=`basename $hollight_file .ml`
 root_path=HOLLight
 jobs='-j32'
 
+one_stage="false"
+
 usage() {
     echo "usage: `basename $0` [STAGE_NUMBER]"
     echo
@@ -256,7 +258,7 @@ stage() {
         echo '------------------------------------------------------------'
         echo stage $*
         $2
-        if test $one_stage -eq "true"
+        if test $one_stage = "true"
         then
             echo 20 > STAGE
         else
@@ -264,6 +266,11 @@ stage() {
         fi
     fi
 }
+
+if test -n "$2"
+then
+    shift
+fi
 
 if test -n "$1"
 then

--- a/reproduce
+++ b/reproduce
@@ -196,11 +196,16 @@ translate_proofs() {
     then
         echo translate HOL-Light proofs to lambdapi and rocq ...
         cd output
-        make split
-        make $jobs lp
-        make $jobs v
-        make $jobs merge-spec-files
-        make $jobs rm-empty-deps
+        echo "time to split files:" > &2
+        time make split
+        echo "time to generate .lp files:" > &2
+        time make $jobs lp
+        echo "time to generate .v files:" > &2
+        time make $jobs v
+        echo "time to merge spec files:" > &2
+        time make $jobs merge-spec-files
+        echo "time to remove empty deps:" > &2
+        time make $jobs rm-empty-deps
         cd ..
     fi
 }
@@ -210,7 +215,8 @@ check_proofs() {
     then
         echo check proofs ...
         cd output
-        make $jobs -k vo
+        echo "time to check .v files:" > &2
+        time make $jobs -k vo
         cd ..
     fi
 }

--- a/reproduce
+++ b/reproduce
@@ -160,12 +160,15 @@ patch_hollight() {
 }
 
 dump_proofs() {
-    if test ! -f hol-light/$hollight_file
+    if test -f hol-light/$hollight_file
     then
         echo dump hol-light proofs ...
         cd hol-light
         hol2dk dump-simp $hollight_file
         cd ..
+    else
+        echo can\'t find $(pwd)/hol-light/$hollight_file. Please make sure to run stages 1 to 5
+        echo and re-run the script from the repository root folder.
     fi
 }
 
@@ -258,6 +261,7 @@ stage() {
         echo '------------------------------------------------------------'
         echo stage $*
         $2
+        touch stage_$1_$2.ok
         if test $one_stage = "true"
         then
             echo 20 > STAGE

--- a/reproduce
+++ b/reproduce
@@ -196,15 +196,15 @@ translate_proofs() {
     then
         echo translate HOL-Light proofs to lambdapi and rocq ...
         cd output
-        echo "time to split files:" > &2
+        echo "time to split files:" >&2
         time make split
-        echo "time to generate .lp files:" > &2
+        echo "time to generate .lp files:" >&2
         time make $jobs lp
-        echo "time to generate .v files:" > &2
+        echo "time to generate .v files:" >&2
         time make $jobs v
-        echo "time to merge spec files:" > &2
+        echo "time to merge spec files:" >&2
         time make $jobs merge-spec-files
-        echo "time to remove empty deps:" > &2
+        echo "time to remove empty deps:" >&2
         time make $jobs rm-empty-deps
         cd ..
     fi
@@ -215,7 +215,7 @@ check_proofs() {
     then
         echo check proofs ...
         cd output
-        echo "time to check .v files:" > &2
+        echo "time to check .v files:" >&2
         time make $jobs -k vo
         cd ..
     fi

--- a/reproduce
+++ b/reproduce
@@ -197,15 +197,15 @@ translate_proofs() {
         echo translate HOL-Light proofs to lambdapi and rocq ...
         cd output
         echo "time to split files:" >&2
-        time make split
+        /bin/bash -c time make split
         echo "time to generate .lp files:" >&2
-        time make $jobs lp
+        /bin/bash -c time make $jobs lp
         echo "time to generate .v files:" >&2
-        time make $jobs v
+        /bin/bash -c time make $jobs v
         echo "time to merge spec files:" >&2
-        time make $jobs merge-spec-files
+        /bin/bash -c time make $jobs merge-spec-files
         echo "time to remove empty deps:" >&2
-        time make $jobs rm-empty-deps
+        /bin/bash -c time make $jobs rm-empty-deps
         cd ..
     fi
 }
@@ -216,7 +216,7 @@ check_proofs() {
         echo check proofs ...
         cd output
         echo "time to check .v files:" >&2
-        time make $jobs -k vo
+        /bin/bash -c time make $jobs -k vo
         cd ..
     fi
 }


### PR DESCRIPTION
This PR is primarily intended as a record of changes. While some modifications may not be immediately relevant, they may prove useful for future developments.

### Fixes in the `reproduce` script
- Fix `dump_proofs`: the initial `if` condition in the function was inverted.
- Shift all non-numerical parameters.
- Fix ask: when the `-y` flag was passed to the script, `ask` did not return any value, which prevented subsequent operations from executing.
### Minor improvements to ease `Docker` image builds
- Add a `--only` flag to allow execution of a single 
- Use `time` to report performance metrics.